### PR TITLE
Dont't output log line even if ASSETS_PREFIX doesn't start with a slash

### DIFF
--- a/lib/quiet_assets.rb
+++ b/lib/quiet_assets.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require "quiet_assets/version"
 
 module QuietAssets
@@ -16,7 +17,7 @@ module QuietAssets
           def call_with_quiet_assets(env)
             old_logger_level, level = Rails.logger.level, Logger::ERROR
             # Increase log level because of messages that have a low level should not be displayed
-            Rails.logger.level = level if env['PATH_INFO'].index(ASSETS_PREFIX) == 0
+            Rails.logger.level = level if env['PATH_INFO'].index(ASSETS_PREFIX)
             call_without_quiet_assets(env)
           ensure
             # Return back


### PR DESCRIPTION
Hi,

today I tried out your gem and found that it didn't work in my projects setup.

The reason was that the configured `assets.prefix` path in my rails 3.1 app didn't start with a slash.

Instead of the assumed `/assets/somepath` it was `assets/somepath`. That's totally legit in my setup.

I just removed the check for `index == 0` (it returns `nil` anyway) and it works fine for me.

If that ok with you please consider pulling the change in.

Thanks for that gem! Those asset log entries really did go on my nerves.

Thanks,
Frank
