### PR TITLE
Next try. ENV["PATH_INFO"] always starts with a /

### DIFF
--- a/lib/quiet_assets.rb
+++ b/lib/quiet_assets.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require "quiet_assets/version"
 
 module QuietAssets
@@ -8,7 +9,8 @@ module QuietAssets
     initializer "quiet_assets", :after => "sprockets.environment" do |app|
       if app.config.quiet_assets == true
         # Parse PATH_INFO by assets prefix
-        ASSETS_PREFIX = app.config.assets.prefix.split("/").join("/") + "/"
+        # env["PATH_INFO"] seems to always start with a /
+        ASSETS_PREFIX = "/#{app.config.assets.prefix}/".gsub(/^\/\//,"/")
         app.config.assets.logger = false
 
         # Just create an alias for call in middleware
@@ -16,7 +18,7 @@ module QuietAssets
           def call_with_quiet_assets(env)
             old_logger_level, level = Rails.logger.level, Logger::ERROR
             # Increase log level because of messages that have a low level should not be displayed
-            Rails.logger.level = level if env['PATH_INFO'].index(ASSETS_PREFIX) == 0
+            Rails.logger.level = level if env['PATH_INFO'].start_with?(ASSETS_PREFIX)
             call_without_quiet_assets(env)
           ensure
             # Return back


### PR DESCRIPTION
I really didn't understand `.prefix.split("/").join("/") + "/"` (why split and then join again?) so i just use the prefix in an interpolation :)

Also replaced `index` with `start_with?`

Makes it work with asset.prefix set to "some/path".

Greetings,
Frank
