### PR TITLE
Dependent of railties instead of rails because it's not needed to have c...

### DIFF
--- a/quiet_assets.gemspec
+++ b/quiet_assets.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "rails", "~> 3.1"
+  gem.add_dependency "railties", "~> 3.1"
 end


### PR DESCRIPTION
because it's not needed to have c...omplete rails dependencies like activerecord if you use another ORM by example.
