### PR TITLE
Allow for arbitrary filtering of logs using lambdas and the env variable

### DIFF
--- a/lib/quiet_assets.rb
+++ b/lib/quiet_assets.rb
@@ -2,21 +2,32 @@ require "quiet_assets/version"
 
 module QuietAssets
   class Engine < ::Rails::Engine
-    # Set as true but user can override it
+    # Set as true and no additions, but user can override it
     config.quiet_assets = true
+    config.quiet_assets_checks = nil
 
     initializer "quiet_assets", :after => "sprockets.environment" do |app|
       if app.config.quiet_assets == true
+
         # Parse PATH_INFO by assets prefix
         ASSETS_PREFIX = "/#{app.config.assets.prefix[/\A\/?(.*?)\/?\z/, 1]}/"
+
+        # silences sprockets logging
         app.config.assets.logger = false
+
+        # if no addition lambdas passed, just quiet assets
+        if !app.config.quiet_assets_checks then app.config.quiet_assets_checks = Array.new end
+        assets_path_check = ->(env){ env['PATH_INFO'].start_with?(ASSETS_PREFIX) }
+        app.config.quiet_assets_checks.unshift(assets_path_check)
 
         # Just create an alias for call in middleware
         Rails::Rack::Logger.class_eval do
           def call_with_quiet_assets(env)
             old_logger_level, level = Rails.logger.level, Logger::ERROR
             # Increase log level because of messages that have a low level should not be displayed
-            Rails.logger.level = level if env['PATH_INFO'].start_with?(ASSETS_PREFIX)
+            Rails.application.config.quiet_assets_checks.each do |check|
+              Rails.logger.level = level if check.call(env)
+            end
             call_without_quiet_assets(env)
           ensure
             # Return back


### PR DESCRIPTION
This change leaves the quiet_assets code intact while allowing the user to add an additional configuration parameter that contains additional filters.  

To use, add this to `application.rb` or an environment file:

```
config.quiet_assets_checks = [ ->(env){ env['PATH_INFO'].start_with?('/health') }, ->(env){ env['PATH_INFO'].start_with?('/admins') } ]
```

Filters can be any predicate that uses the `env` variable.
