### PR TITLE
Dependent of railties ">= 3.1", "< 5.0" will work with rails 4.*

### DIFF
--- a/quiet_assets.gemspec
+++ b/quiet_assets.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "railties", "~> 3.1"
+  gem.add_dependency "railties", ">= 3.1", "< 5.0"
 end


### PR DESCRIPTION
Hi. quiet_assets with current Edge rails (railties 4.0.0.beta) raise an error:

``` ruby
Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    quiet_assets (>= 0) ruby depends on
      railties (~> 3.1) ruby

    rails (>= 0) ruby depends on
      railties (4.0.0.beta)

Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    quiet_assets (>= 0) ruby depends on
      rails (~> 3.1) ruby

    rails (4.0.0.beta)
```
