### PR TITLE
Correct test file listed in gemspec

### DIFF
--- a/quiet_assets.gemspec
+++ b/quiet_assets.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
 
   gem.files         = %w(LICENSE README.md lib/quiet_assets.rb quiet_assets.gemspec)
   gem.require_paths = %w(lib)
-  gem.test_files    = %w(tests/test_quiet_assets.rb)
+  gem.test_files    = %w(test/test_quiet_assets.rb)
 
   gem.add_dependency 'railties', '>= 3.1', '< 5.0'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
It fails to build the gem if gemspec contains an incorrect or missing file.

This fix a Bundler error:

```
.bundle/bundler/gems/quiet_assets-fd2ea5bfac9d did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["tests/test_quiet_assets.rb"] are not files
```

This is reproducible with a clean checkout of the repository and RubyGems directly:

```
$ gem build quiet_assets.gemspec 
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["tests/test_quiet_assets.rb"] are not files
```

Cheers! and thank you for this!

:heart: :heart: :heart: 
