### PR TITLE
Add config.quiet_assets_paths option to suppress additional paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ place the following in your `config/application.rb` file:
 
     config.quiet_assets = false
 
+If you need to supress output for other paths you can do so by specifying:
+
+    config.quiet_assets_paths << '/silent/'
+
 ## License
 
 Dual licensed under the MIT or GPL licenses:

--- a/lib/quiet_assets.rb
+++ b/lib/quiet_assets.rb
@@ -4,11 +4,15 @@ module QuietAssets
   class Engine < ::Rails::Engine
     # Set as true but user can override it
     config.quiet_assets = true
+    config.quiet_assets_paths = []
 
     initializer 'quiet_assets', :after => 'sprockets.environment' do |app|
       next unless app.config.quiet_assets
       # Parse PATH_INFO by assets prefix
-      ASSETS_PREFIX = "/#{app.config.assets.prefix[/\A\/?(.*?)\/?\z/, 1]}/"
+      paths = ["/#{app.config.assets.prefix[/\A\/?(.*?)\/?\z/, 1]}/"]
+      # Add additional paths
+      paths += [*config.quiet_assets_paths]
+      ASSETS_REGEX = /\A(#{paths.join('|')})/
       KEY = 'quiet_assets.old_level'
       app.config.assets.logger = false
 
@@ -16,7 +20,7 @@ module QuietAssets
       Rails::Rack::Logger.class_eval do
         def call_with_quiet_assets(env)
           begin
-            if env['PATH_INFO'].start_with?(ASSETS_PREFIX)
+            if env['PATH_INFO'] =~ ASSETS_REGEX
               env[KEY] = Rails.logger.level
               Rails.logger.level = Logger::ERROR
             end

--- a/test/test_quiet_assets.rb
+++ b/test/test_quiet_assets.rb
@@ -34,6 +34,7 @@ class HelperTest < Test::Unit::TestCase
       routes {
         root :to => 'home#index'
         get 'assets/picture' => 'home#index'
+        get 'quiet/this' => 'home#index'
       }
     end
   end
@@ -107,4 +108,37 @@ class HelperTest < Test::Unit::TestCase
 
     assert_match(/Started GET \"\/\" for  at/, output.string)
   end
+
+  def test_quiet_url
+    initialize!
+
+    app.call request('/quiet/this')
+
+    assert_match(/Started GET \"\/quiet\/this\" for  at/, output.string)
+  end
+
+  def test_quiet_url_with_paths_option_as_string_equality
+    initialize! { config.quiet_assets_paths = '/quiet/' }
+
+    app.call request('/quiet/this')
+
+    assert_equal '', output.string
+  end
+
+  def test_quiet_url_with_paths_option_as_string_appending
+    initialize! { config.quiet_assets_paths << '/quiet/' }
+
+    app.call request('/quiet/this')
+
+    assert_equal '', output.string
+  end
+
+  def test_quiet_url_with_paths_option_as_array
+    initialize! { config.quiet_assets_paths += ['/quiet/'] }
+
+    app.call request('/quiet/this')
+
+    assert_equal '', output.string
+  end
+
 end


### PR DESCRIPTION
I needed a way to silence some additional output in the development log that was annoying me.  I extended quiet_assets to take additional paths and if set use them in addition to the asset path.  Tests included and readme updated.

Addresses #26 as well.

Thanks!
