### PR TITLE
Fix alias_method_chain deprecation warnings in Rails 5

### DIFF
--- a/lib/quiet_assets.rb
+++ b/lib/quiet_assets.rb
@@ -17,20 +17,20 @@ module QuietAssets
       app.config.assets.logger = false
 
       # Just create an alias for call in middleware
-      Rails::Rack::Logger.class_eval do
-        def call_with_quiet_assets(env)
+      module RackWithQuietAssets
+        def call(env)
           begin
             if env['PATH_INFO'] =~ ASSETS_REGEX
               env[KEY] = Rails.logger.level
               Rails.logger.level = Logger::ERROR
             end
-            call_without_quiet_assets(env)
+            super(env)
           ensure
             Rails.logger.level = env[KEY] if env[KEY]
           end
         end
-        alias_method_chain :call, :quiet_assets
-      end
+      
+      Rails::Rack::Logger.send(:prepend, RackWithQuietAssets)
     end
   end
 end

--- a/lib/quiet_assets.rb
+++ b/lib/quiet_assets.rb
@@ -29,6 +29,7 @@ module QuietAssets
             Rails.logger.level = env[KEY] if env[KEY]
           end
         end
+      end
       
       Rails::Rack::Logger.send(:prepend, RackWithQuietAssets)
     end


### PR DESCRIPTION
alias_method_chain is deprecated, replaced by Module.prepend.

Updated to match http://www.justinweiss.com/blog/2014/09/08/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/

Only thing I am unsure of is legacy support...