### PR TITLE
Deprecation in favour of config in sprockets-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.1.1
+=====
+
+Add deprecation message. Replaced by a config in `sprockets-rails` version `3.1.0`
+
 1.1.0
 =====
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Quiet Assets
 [![Continuous Integration status](https://api.travis-ci.org/evrone/quiet_assets.svg)](http://travis-ci.org/evrone/quiet_assets)
 
+## Deprecation
+
+As of `sprockets-rails` version `3.1.0`, used in current versions of rails, this gem is deprecated.
+
+The asset pipeline now supports a `quiet` option which suppresses output of asset requests:
+
+```
+# config/environments/development.rb
+
+config.assets.quiet = true
+```
+
+Relevant PR: https://github.com/rails/sprockets-rails/pull/355
+
+
+## Info
+
 Quiet Assets turns off the Rails asset pipeline log. This means that it suppresses messages in your development log such as:
 
     Started GET "/assets/application.js" for 127.0.0.1 at 2015-01-28 13:35:34 +0300

--- a/quiet_assets.gemspec
+++ b/quiet_assets.gemspec
@@ -1,12 +1,20 @@
 Gem::Specification.new do |gem|
   gem.name          = 'quiet_assets'
-  gem.version       = '1.1.0'
+  gem.version       = '1.1.1'
   gem.authors       = ['Dmitry Karpunin', 'Dmitry Vorotilin']
   gem.email         = ['koderfunk@gmail.com', 'd.vorotilin@gmail.com']
   gem.homepage      = 'http://github.com/evrone/quiet_assets'
   gem.description   = 'Quiet Assets turns off Rails asset pipeline log.'
   gem.summary       = 'Turns off Rails asset pipeline log.'
   gem.licenses      = ['MIT', 'GPL']
+
+  gem.post_install_message = "*** quiet_assets deprecation
+The `quiet_assets` gem is now deprecated. The functionality has been pulled into `sprockets-rails` as of version 3.1.0.
+Add the following line to `config/environments/development.rb`:
+
+    config.assets.quiet = true
+
+This is the default for new rails apps."
 
   gem.files         = %w(LICENSE README.md lib/quiet_assets.rb quiet_assets.gemspec)
   gem.require_paths = %w(lib)


### PR DESCRIPTION
@route @evrone

The functionality this gem provides, quieting asset request, has been pulled into `sprockets-rails` `3.1.0` as a configuration. https://github.com/rails/sprockets-rails/pull/355

Bumping the version of this gem to `1.1.1` and the only change is a deprecation description to the `README` and adding a post install message to the gem explaining how the gem is deprecated.