### PR TITLE
Upgrade railties dependency version

### DIFF
--- a/quiet_assets.gemspec
+++ b/quiet_assets.gemspec
@@ -20,7 +20,7 @@ This is the default for new rails apps."
   gem.require_paths = %w(lib)
   gem.test_files    = %w(test/test_quiet_assets.rb)
 
-  gem.add_dependency 'railties', '>= 3.1', '< 5.0'
+  gem.add_dependency 'railties', '>= 4.0', '< 5.2'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'tzinfo'
 end


### PR DESCRIPTION
For Rails latest upgrade, railties dependency needs to be resolved.